### PR TITLE
Fix README target line

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You need to set two environment variables:
 LIBSVCHOOK=./apps/basic/libsvchook_basic.so LD_PRELOAD=./libsvchook.so [target]
 ```
 
-Replace `[target]` with the binary you wish to hook system call.
+Replace `[target]` with the binary whose system calls you wish to hook.
 
 #### Example Output
 


### PR DESCRIPTION
## Summary
- clarify instructions for `[target]` in README

## Testing
- `make fmt`
- `make -C apps/basic fmt`
- `make` *(fails: operand size mismatch for ARM64 instructions)*

------
https://chatgpt.com/codex/tasks/task_e_6843ab7f02ac8320ae0f00d713053d51