### PR TITLE
ci: Refactoring CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
           make -C apps/basic clean
           make
           make -C apps/basic
-          LIBSVCHOOK=./apps/basic/libsvchook_basic.so LD_PRELOAD=./libsvchook.so ls
+          LIBSVCHOOK=./apps/basic/libsvchook_basic.so LD_PRELOAD=./libsvchook.so ls | grep "output from hook_function"
       - name: Format
         run: |
           make fmt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,25 +9,18 @@ jobs:
   linux-build:
     name: Build
     runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        SYSCALL_RECORD: [0, 1]
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Build/Test (default)
+      - name: Build/Test
         env:
-          PARANOID: 0
-          SYSCALL_RECORD: 0
-        run: |
-          make clean
-          make -C apps/basic clean
-          make
-          make -C apps/basic
-          LIBSVCHOOK=./apps/basic/libsvchook_basic.so LD_PRELOAD=./libsvchook.so ls
-      - name: Build/Test (paranoid/record)
-        env:
-          PARANOID: 1
-          SYSCALL_RECORD: 1
+          SYSCALL_RECORD: ${{ matrix.SYSCALL_RECORD }}
         run: |
           make clean
           make -C apps/basic clean
@@ -42,6 +35,10 @@ jobs:
   android-build:
     name: Android Cross Build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SYSCALL_RECORD: [0, 1]
     env:
       ANDROID_VERSION: 21
     steps:
@@ -49,22 +46,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Build (default)
+      - name: Build
         env:
           CC: aarch64-linux-android${{ env.ANDROID_VERSION }}-clang
-          PARANOID: 0
-          SYSCALL_RECORD: 0
-        run: |
-          export PATH=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH
-          make clean
-          make -C apps/basic clean
-          make
-          make -C apps/basic
-      - name: Build (paranoid/record)
-        env:
-          CC: aarch64-linux-android${{ env.ANDROID_VERSION }}-clang
-          PARANOID: 1
-          SYSCALL_RECORD: 1
+          SYSCALL_RECORD: ${{ matrix.SYSCALL_RECORD }}
         run: |
           export PATH=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH
           make clean


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to streamline the build process and introduce matrix-based testing for different configurations. The changes primarily focus on simplifying the workflow definitions and enabling parallel builds for varying `SYSCALL_RECORD` values.

### Workflow updates:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R12-R29): Added a matrix strategy to both `linux-build` and `android-build` jobs, allowing builds to run with `SYSCALL_RECORD` set to `0` and `1` in parallel. This eliminates the need for separate steps for default and paranoid/record configurations. [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R12-R29) [[2]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R38-R52)

### Build process simplification:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R12-R29): Removed redundant environment variables (`PARANOID`) and merged the previously separate build steps into a single step for each job, leveraging the matrix configuration. [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R12-R29) [[2]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R38-R52)

### Output validation:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R12-R29): Updated the `linux-build` job to include output validation by piping the `ls` command's output through `grep` to check for specific text from `hook_function`.