### PR TITLE
Fix memory size calculation for ARM64 trampoline

### DIFF
--- a/main.c
+++ b/main.c
@@ -668,7 +668,7 @@ static void setup_trampoline(void) {
     assert(entry->count <= entry->records_size_max);
 
     const size_t mem_size =
-        align_up(jump_code_size + gate_size * sizeof(uint32_t) * entry->count,
+        align_up((jump_code_size + gate_size * entry->count) * sizeof(uint32_t),
                  PAGE_SIZE);
 
     assert(range_min + mem_size <= range_max);


### PR DESCRIPTION
## Summary
- fix calculation of allocated memory for per-SVC trampolines

## Testing
- `make fmt`

------
https://chatgpt.com/codex/tasks/task_e_6843aa1e65ec83208c03c489d4a6135d