### PR TITLE
Add FreeBSD build support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,29 @@ jobs:
           make fmt
           make -C apps/basic fmt
           test -z "$(git status --porcelain)"
+  freebsd-build:
+    name: FreeBSD Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build on FreeBSD
+        uses: vmactions/freebsd-vm@v1
+        with:
+          arch: aarch64
+          usesh: true
+          prepare: |
+            pkg install -y llvm
+          run: |
+            make clean
+            make -C apps/basic clean
+            make
+            make -C apps/basic
+            make fmt
+            make -C apps/basic fmt
+            test -z "$(git status --porcelain)"
   android-build:
     name: Android Cross Build
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ PROGS = libsvchook.so
 
 CLANG_FORMAT ?= clang-format
 
+SYSCALL_RECORD ?= 0
+
 CLEANFILES = $(PROGS) *.o *.d
 
 CFLAGS = -O3
@@ -16,14 +18,12 @@ CFLAGS += -Wall
 CFLAGS += -Wunused-function
 CFLAGS += -Wextra
 CFLAGS += -fPIC
+CFLAGS += -DSUPPLEMENTAL__SYSCALL_RECORD=$(SYSCALL_RECORD)
 
-ifeq ($(SYSCALL_RECORD), 1)
-CFLAGS += -DSUPPLEMENTAL__SYSCALL_RECORD
-endif
-
+LIBDL ?= -ldl
 LDFLAGS += -shared
 LDFLAGS += -rdynamic
-LDFLAGS += -ldl
+LDFLAGS += $(LIBDL)
 
 C_SRCS = main.c
 OBJS = $(C_SRCS:.c=.o)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Read [my blog post (ja)](https://retrage.github.io/2024/07/31/svc-hook.html/) fo
 
 ## Target Platform
 
-svc-hook supports ARM64 Linux.
+svc-hook supports ARM64 Linux and FreeBSD.
 
 ## Build
 

--- a/apps/basic/Makefile
+++ b/apps/basic/Makefile
@@ -24,7 +24,7 @@ OBJS = $(C_SRCS:.c=.o)
 all: $(PROGS)
 
 $(PROGS): $(OBJS)
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS)
 
 clean:
 	-@rm -rf $(CLEANFILES)


### PR DESCRIPTION
## Summary
- support BSD and GNU Make
- parse /proc maps on FreeBSD
- document FreeBSD development with QEMU rootfs
- add CI job that builds on FreeBSD
- split scan_code function per operating system

## Testing
- `make clean && make CC=aarch64-linux-gnu-gcc`
- `bmake CC=aarch64-linux-gnu-gcc`
- `CC=aarch64-linux-gnu-gcc make -C apps/basic`

------
https://chatgpt.com/codex/tasks/task_e_684978360c98832085d5e9b070b5940c