### PR TITLE
Add NetBSD support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,29 @@ jobs:
             make fmt
             make -C apps/basic fmt
             test -z "$(git status --porcelain)"
+  netbsd-build:
+    name: NetBSD Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build on NetBSD
+        uses: vmactions/netbsd-vm@v1
+        with:
+          arch: aarch64
+          usesh: true
+          prepare: |
+            pkg_add clang
+          run: |
+            bmake clean
+            bmake -C apps/basic clean
+            bmake
+            bmake -C apps/basic
+            bmake fmt
+            bmake -C apps/basic fmt
+            test -z "$(git status --porcelain)"
   android-build:
     name: Android Cross Build
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
-#!/usr/bin/env make
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2025 Akira Moroo
 
+CC ?= clang
 PROGS = libsvchook.so
 
 CLANG_FORMAT ?= clang-format
 
 SYSCALL_RECORD ?= 0
+NO_MAN=
 
 CLEANFILES = $(PROGS) *.o *.d
 
@@ -31,7 +32,7 @@ OBJS = $(C_SRCS:.c=.o)
 all: $(PROGS)
 
 $(PROGS): $(OBJS)
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $? $(LDFLAGS)
 
 clean:
 	-@rm -rf $(CLEANFILES)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Read [my blog post (ja)](https://retrage.github.io/2024/07/31/svc-hook.html/) fo
 
 ## Target Platform
 
-svc-hook supports ARM64 Linux and FreeBSD.
+svc-hook supports ARM64 Linux, FreeBSD and NetBSD.
 
 ## Build
 
@@ -31,6 +31,18 @@ To build a simple hook application `libsvchook_basic.so`, use:
 make -C apps/basic
 ```
 
+
+### NetBSD Development Environment
+
+You can build and test svc-hook on NetBSD using user mode QEMU. Install
+`qemu-user` and `bmake` on your development system:
+
+```shell
+sudo apt-get install qemu-user bmake
+```
+
+Then build the project with `bmake` or run the NetBSD binaries using
+`qemu-aarch64`. The Makefiles are compatible with both GNU Make and BSD Make.
 ## Usage
 
 You need to set two environment variables:

--- a/apps/basic/Makefile
+++ b/apps/basic/Makefile
@@ -1,10 +1,11 @@
-#!/usr/bin/env make
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2025 Akira Moroo
 
+CC ?= clang
 PROGS = libsvchook_basic.so
 
 CLANG_FORMAT ?= clang-format
+NO_MAN=
 
 CLEANFILES = $(PROGS) *.o *.d
 
@@ -24,7 +25,7 @@ OBJS = $(C_SRCS:.c=.o)
 all: $(PROGS)
 
 $(PROGS): $(OBJS)
-	$(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $? $(LDFLAGS)
 
 clean:
 	-@rm -rf $(CLEANFILES)

--- a/main.c
+++ b/main.c
@@ -18,8 +18,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__)
 #define PROCFS_MAP "/proc/self/map"
+#elif defined(__NetBSD__)
+#define PROCFS_MAP "/proc/curproc/map"
 #else
 #define PROCFS_MAP "/proc/self/maps"
 #endif
@@ -120,8 +122,9 @@ void ____asm_impl(void) {
       "adrp x6, :got:syscall_table \n\t"
       "ldr x6, [x6, #:got_lo12:syscall_table] \n\t"
       "ldr x6, [x6] \n\t"
-      "add x6, x6, xzr, lsl #3 \n\t"
-      "br x6 \n\t");
+      "lsl x8, x8, #3 \n\t"
+      "add x8, x8, x6 \n\t"
+      "br x8 \n\t");
 
   /*
    * asm_syscall_hook is the address where the
@@ -508,7 +511,7 @@ static void scan_exec_code(char *code, size_t code_size, int mem_prot,
   close(fd);
 }
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__)
 /* entry point for binary scanning on FreeBSD */
 static void scan_code(void) {
   LIST_INIT(&head);
@@ -553,6 +556,57 @@ static void scan_code(void) {
           break;
       }
       if (i == 9) break;
+      c = strtok(NULL, " ");
+      i++;
+    }
+  }
+  fclose(fp);
+}
+#elif defined(__NetBSD__)
+/* entry point for binary scanning on NetBSD */
+static void scan_code(void) {
+  LIST_INIT(&head);
+
+  FILE *fp = NULL;
+  /* get memory mapping information from procfs */
+  assert((fp = fopen(PROCFS_MAP, "r")) != NULL);
+  char buf[4096];
+  while (fgets(buf, sizeof(buf), fp) != NULL) {
+    /* we do not touch stack memory */
+    if (strstr(buf, "[stack]") != NULL) {
+      continue;
+    }
+    int mem_prot = 0;
+    int i = 0;
+    char from_addr[65] = {0};
+    char to_addr[65] = {0};
+    char *c = strtok(buf, " ");
+    while (c != NULL) {
+      switch (i) {
+        case 0:
+          strncpy(from_addr, c, sizeof(from_addr) - 1);
+          break;
+        case 1:
+          strncpy(to_addr, c, sizeof(to_addr) - 1);
+          break;
+        case 2:
+          for (size_t j = 0; j < strlen(c); j++) {
+            if (c[j] == 'r') mem_prot |= PROT_READ;
+            if (c[j] == 'w') mem_prot |= PROT_WRITE;
+            if (c[j] == 'x') mem_prot |= PROT_EXEC;
+          }
+          break;
+        case 4:
+          if (strncmp(c, "COW", 3) == 0) {
+            int64_t from = strtol(&from_addr[0], NULL, 16);
+            int64_t to = strtol(&to_addr[0], NULL, 16);
+            if (mem_prot & PROT_EXEC) {
+              scan_exec_code((char *)from, (size_t)to - from, mem_prot, NULL);
+            }
+          }
+          break;
+      }
+      if (i == 4) break;
       c = strtok(NULL, " ");
       i++;
     }


### PR DESCRIPTION
## Summary
- compile with BSD `bmake`
- support NetBSD procfs map path
- update syscall trampoline for multiple OSes
- document NetBSD dev setup
- test NetBSD build in CI

## Testing
- `make fmt`
- `make -C apps/basic fmt`
- `make` *(fails: missing aarch64 cross compiler)*

------
https://chatgpt.com/codex/tasks/task_e_684ae904f7048320acb1453ee076931e